### PR TITLE
[react] Create Grid component

### DIFF
--- a/apps/pigment-css-next-app/src/app/grid/demo3.tsx
+++ b/apps/pigment-css-next-app/src/app/grid/demo3.tsx
@@ -1,0 +1,43 @@
+'use client';
+import * as React from 'react';
+import Grid from '@pigment-css/react/Grid';
+import { styled } from '@pigment-css/react';
+
+const Item = styled.div`
+  background-color: #fff;
+  border: 1px solid #ced7e0;
+  padding: 8px;
+  border-radius: 4px;
+  text-align: center;
+`;
+
+export default function GridDemo3() {
+  const [spacing, setSpacing] = React.useState(2);
+  return (
+    <div sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <Grid container spacing={spacing} sx={{ justifyContent: 'center' }}>
+          {[0, 1, 2].map((value) => (
+            <Grid key={value}>
+            <Item
+              sx={{
+                height: 140,
+                width: 100,
+              }}
+              />
+            </Grid>
+          ))}
+      </Grid>
+      <Grid container spacing={1} sx={{ justifyContent: 'center' }} >
+        <Grid size={'auto'}>Spacing:</Grid>
+        {[0, 0.5, 1, 2, 3, 4, 8, 12].map((value) => (
+          <Grid key={value} size={'auto'}>
+            <label>
+              <input type="radio" name="radio" value={value} checked={value === spacing} onChange={(e) => setSpacing(parseFloat(e.target.value))} />
+              {value}
+            </label>
+          </Grid>
+        ))}
+        </Grid>
+    </div>
+  )
+}

--- a/apps/pigment-css-next-app/src/app/grid/page.tsx
+++ b/apps/pigment-css-next-app/src/app/grid/page.tsx
@@ -1,0 +1,272 @@
+import Box from '@pigment-css/react/Box';
+import Grid from '@pigment-css/react/Grid';
+import { styled } from '@pigment-css/react';
+import GridDemo3 from './demo3';
+
+const Item = styled.div`
+  background-color: #fff;
+  border: 1px solid #ced7e0;
+  padding: 8px;
+  border-radius: 4px;
+  text-align: center;
+`;
+
+function GridDemo1() {
+  return (
+    <Grid container spacing={2}>
+      <Grid size={8}>
+        <Item>size=8</Item>
+      </Grid>
+      <Grid size={4}>
+        <Item>size=4</Item>
+      </Grid>
+      <Grid size={4}>
+        <Item>size=4</Item>
+      </Grid>
+      <Grid size={8}>
+        <Item>size=8</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+function GridDemo2() {
+  return (
+    <Grid container spacing={2}>
+      <Grid size={{ xs: 6, md: 8 }}>
+        <Item>xs=6 md=8</Item>
+      </Grid>
+      <Grid size={{ xs: 6, md: 4 }}>
+        <Item>xs=6 md=4</Item>
+      </Grid>
+      <Grid size={{ xs: 6, md: 4 }}>
+        <Item>xs=6 md=4</Item>
+      </Grid>
+      <Grid size={{ xs: 6, md: 8 }}>
+        <Item>xs=6 md=8</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+function GridDemo4() {
+  return (
+    <Grid container rowSpacing={1} columnSpacing={{ xs: 1, sm: 2, md: 3 }}>
+      <Grid size={6}>
+        <Item>1</Item>
+      </Grid>
+      <Grid size={6}>
+        <Item>2</Item>
+      </Grid>
+      <Grid size={6}>
+        <Item>3</Item>
+      </Grid>
+      <Grid size={6}>
+        <Item>4</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+function GridDemo5() {
+  return (
+    <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 4, sm: 8, md: 12 }}>
+      {Array.from(Array(6)).map((_, index) => (
+        <Grid size={{ xs: 2, sm: 4 }} key={index}>
+          <Item>{index + 1}</Item>
+        </Grid>
+      ))}
+    </Grid>
+  )
+}
+
+function GridDemo6() {
+  return (
+    <Grid container spacing={3}>
+      <Grid size="grow">
+        <Item>grow</Item>
+      </Grid>
+      <Grid size={6}>
+        <Item>size=6</Item>
+      </Grid>
+      <Grid size="grow">
+        <Item>grow</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+function GridDemo7() {
+  return (
+    <Grid container spacing={3}>
+      <Grid size="auto">
+        <Item>Variable width item</Item>
+      </Grid>
+      <Grid size={6}>
+        <Item>size=6</Item>
+      </Grid>
+      <Grid size="grow">
+        <Item>grow</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+function GridDemo8() {
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, md: 5, lg: 4 }}>
+          <Item>Email subscribe section</Item>
+        </Grid>
+        <Grid container size={{ xs: 12, md: 7, lg: 8 }} spacing={4}>
+          <Grid size={{ xs: 6, lg: 3 }}>
+            <Item>
+              <Box
+                id="category-a"
+                sx={{ fontSize: '12px', textTransform: 'uppercase' }}
+              >
+                Category A
+              </Box>
+              <Box component="ul" aria-labelledby="category-a" sx={{ pl: 2 }}>
+                <li>Link 1.1</li>
+                <li>Link 1.2</li>
+                <li>Link 1.3</li>
+              </Box>
+            </Item>
+          </Grid>
+          <Grid size={{ xs: 6, lg: 3 }}>
+            <Item>
+              <Box
+                id="category-b"
+                sx={{ fontSize: '12px', textTransform: 'uppercase' }}
+              >
+                Category B
+              </Box>
+              <Box component="ul" aria-labelledby="category-b" sx={{ pl: 2 }}>
+                <li>Link 2.1</li>
+                <li>Link 2.2</li>
+                <li>Link 2.3</li>
+              </Box>
+            </Item>
+          </Grid>
+          <Grid size={{ xs: 6, lg: 3 }}>
+            <Item>
+              <Box
+                id="category-c"
+                sx={{ fontSize: '12px', textTransform: 'uppercase' }}
+              >
+                Category C
+              </Box>
+              <Box component="ul" aria-labelledby="category-c" sx={{ pl: 2 }}>
+                <li>Link 3.1</li>
+                <li>Link 3.2</li>
+                <li>Link 3.3</li>
+              </Box>
+            </Item>
+          </Grid>
+          <Grid size={{ xs: 6, lg: 3 }}>
+            <Item>
+              <Box
+                id="category-d"
+                sx={{ fontSize: '12px', textTransform: 'uppercase' }}
+              >
+                Category D
+              </Box>
+              <Box component="ul" aria-labelledby="category-d" sx={{ pl: 2 }}>
+                <li>Link 4.1</li>
+                <li>Link 4.2</li>
+                <li>Link 4.3</li>
+              </Box>
+            </Item>
+          </Grid>
+        </Grid>
+        <Grid
+          size={12}
+          container
+          direction={{ xs: 'column', sm: 'row' }}
+          sx={{ fontSize: '12px', justifyContent: 'space-between', alignItems: 'center'}}
+        >
+          <Grid sx={{ order: { xs: 2, sm: 1 } }}>
+            <Item>© Copyright</Item>
+          </Grid>
+          <Grid container columnSpacing={1} sx={{ order: { xs: 1, sm: 2 } }}>
+            <Grid>
+              <Item>Link A</Item>
+            </Grid>
+            <Grid>
+              <Item>Link B</Item>
+            </Grid>
+            <Grid>
+              <Item>Link C</Item>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Box>
+  )
+}
+
+function GridDemo9() {
+  return (
+    <Grid container spacing={2} columns={16}>
+      <Grid size={{xs: 8}}>
+        <Item>size=8</Item>
+      </Grid>
+      <Grid size={{xs: 8}}>
+        <Item>size=8</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+function GridDemo10() {
+  return (
+    <Grid container spacing={3} sx={{ flexGrow: 1 }}>
+      <Grid size={{ xs: 6, md: 2 }} offset={{ xs: 3, md: 0 }}>
+        <Item>1</Item>
+      </Grid>
+      <Grid size={{ xs: 4, md: 2 }} offset={{ md: "auto" }}>
+        <Item>2</Item>
+      </Grid>
+      <Grid size={{ xs: 4, md: 2 }} offset={{ xs: 4, md: 0 }} >
+        <Item>3</Item>
+      </Grid>
+      <Grid size={{ xs: 'grow', md: 6 }} offset={{ md: 2 }}>
+        <Item>4</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+const demos = [
+  { id: '1', component: GridDemo1 },
+  { id: '2', component: GridDemo2 },
+  { id: '3', component: GridDemo3 },
+  { id: '4', component: GridDemo4 },
+  { id: '5', component: GridDemo5 },
+  { id: '6', component: GridDemo6 },
+  { id: '7', component: GridDemo7 },
+  { id: '8', component: GridDemo8 },
+  { id: '9', component: GridDemo9 },
+  { id: '10', component: GridDemo10 },
+]
+
+export default function InteractiveGrid() {
+
+  return (
+    <div sx={{ p: 2, mb: 16, display: 'flex', flexDirection: 'column', gap: 2}}>
+      <a href="https://mui.com/system/react-grid">Benchmark v5</a>
+      <a href="https://next.mui.com/system/react-grid">Benchmark next</a>
+      {demos.map(demo => {
+        const Demo = demo.component;
+        return (
+          <div key={demo.id} sx={{ flex: '1 1 0', pb: 4, borderBottom: '1px solid gray' }}>
+            <h3>Grid Demo {demo.id}</h3>
+            <Demo />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/pigment-css-vite-app/src/pages/grid.tsx
+++ b/apps/pigment-css-vite-app/src/pages/grid.tsx
@@ -3,48 +3,32 @@ import Grid from '@pigment-css/react/Grid';
 import { styled } from '@pigment-css/react';
 
 const Card = styled.div`
-  transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  background-color: #fff;
+  border: 1px solid #ced7e0;
+  padding: 8px;
   border-radius: 4px;
-  box-shadow:
-    rgba(0, 0, 0, 0.2) 0px 2px 1px -1px,
-    rgba(0, 0, 0, 0.14) 0px 1px 1px 0px,
-    rgba(0, 0, 0, 0.12) 0px 1px 3px 0px;
-  background-image: linear-gradient(rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.05));
-  padding: 8px 16px;
-  font-family: Roboto, Helvetica, Arial, sans-serif;
-  font-weight: 400;
-  font-size: 0.875rem;
-  line-height: 1.43;
-  letter-spacing: 0.01071em;
-  background-color: rgb(26, 32, 39);
-  width: 100%;
-  text-wrap: nowrap;
-  color: white;
+  text-align: center;
 `;
 
 const items = [
-  { id: '1', size: 1, offset: 0},
-  { id: '2', size: 1, offset: 0},
-  { id: '3', size: 1, offset: 0},
-  { id: '4', size: 1, offset: 0},
-  { id: '5', size: 1, offset: 0},
-  { id: '6', size: 1, offset: 0},
+  { id: '1', size: 2},
+  { id: '2', size: 2},
 ]
 
 export default function InteractiveGrid() {
 
   return (
+    <div sx={{ p: 2}}>
     <Grid
         container
-        columnSpacing={2}
-        rowSpacing={1}
-        columns={{ xs: 2, md: 6 }}
-        direction={'row'}
+        spacing={{ xs: 2, md: 3 }}
+        columns={12}
         sx={{ width: '100%' }}
       >
-        {items.map(({ id, size, offset}) => (
-          <Grid key={id} size={size} offset={offset}><Card>Item {id}</Card></Grid>
+        {items.map(({ id, size, offset, extraText}) => (
+          <Grid key={id} size={size} offset={offset}><Card>Item {id}{extraText}</Card></Grid>
         ))}
       </Grid>
+      </div>
   );
 }

--- a/apps/pigment-css-vite-app/src/pages/grid.tsx
+++ b/apps/pigment-css-vite-app/src/pages/grid.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import Box from '@pigment-css/react/Box';
 import Grid from '@pigment-css/react/Grid';
 import { styled } from '@pigment-css/react';
 
-const Card = styled.div`
+const Item = styled.div`
   background-color: #fff;
   border: 1px solid #ced7e0;
   padding: 8px;
@@ -10,25 +11,293 @@ const Card = styled.div`
   text-align: center;
 `;
 
-const items = [
-  { id: '1', size: 2},
-  { id: '2', size: 2},
+function GridDemo1() {
+  return (
+    <Grid container spacing={2}>
+      <Grid size={8}>
+        <Item>size=8</Item>
+      </Grid>
+      <Grid size={4}>
+        <Item>size=4</Item>
+      </Grid>
+      <Grid size={4}>
+        <Item>size=4</Item>
+      </Grid>
+      <Grid size={8}>
+        <Item>size=8</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+function GridDemo2() {
+  return (
+    <Grid container spacing={2}>
+      <Grid size={{ xs: 6, md: 8 }}>
+        <Item>xs=6 md=8</Item>
+      </Grid>
+      <Grid size={{ xs: 6, md: 4 }}>
+        <Item>xs=6 md=4</Item>
+      </Grid>
+      <Grid size={{ xs: 6, md: 4 }}>
+        <Item>xs=6 md=4</Item>
+      </Grid>
+      <Grid size={{ xs: 6, md: 8 }}>
+        <Item>xs=6 md=8</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+function GridDemo3() {
+  const [spacing, setSpacing] = React.useState(2);
+  return (
+    <div sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <Grid container spacing={spacing} sx={{ justifyContent: 'center' }}>
+          {[0, 1, 2].map((value) => (
+            <Grid key={value}>
+            <Item
+              sx={{
+                height: 140,
+                width: 100,
+              }}
+              />
+            </Grid>
+          ))}
+      </Grid>
+      <Grid container spacing={1} sx={{ justifyContent: 'center' }} >
+        <Grid size={'auto'}>Spacing:</Grid>
+        {[0, 0.5, 1, 2, 3, 4, 8, 12].map((value) => (
+          <Grid key={value} size={'auto'}>
+            <label>
+              <input type="radio" name="radio" value={value} checked={value === spacing} onChange={(e) => setSpacing(parseFloat(e.target.value))} />
+              {value}
+            </label>
+          </Grid>
+        ))}
+        </Grid>
+    </div>
+  )
+}
+
+function GridDemo4() {
+  return (
+    <Grid container rowSpacing={1} columnSpacing={{ xs: 1, sm: 2, md: 3 }}>
+      <Grid size={6}>
+        <Item>1</Item>
+      </Grid>
+      <Grid size={6}>
+        <Item>2</Item>
+      </Grid>
+      <Grid size={6}>
+        <Item>3</Item>
+      </Grid>
+      <Grid size={6}>
+        <Item>4</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+function GridDemo5() {
+  return (
+    <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 4, sm: 8, md: 12 }}>
+      {Array.from(Array(6)).map((_, index) => (
+        <Grid size={{ xs: 2, sm: 4 }} key={index}>
+          <Item>{index + 1}</Item>
+        </Grid>
+      ))}
+    </Grid>
+  )
+}
+
+function GridDemo6() {
+  return (
+    <Grid container spacing={3}>
+      <Grid size="grow">
+        <Item>grow</Item>
+      </Grid>
+      <Grid size={6}>
+        <Item>size=6</Item>
+      </Grid>
+      <Grid size="grow">
+        <Item>grow</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+function GridDemo7() {
+  return (
+    <Grid container spacing={3}>
+      <Grid size="auto">
+        <Item>Variable width item</Item>
+      </Grid>
+      <Grid size={6}>
+        <Item>size=6</Item>
+      </Grid>
+      <Grid size="grow">
+        <Item>grow</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+function GridDemo8() {
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, md: 5, lg: 4 }}>
+          <Item>Email subscribe section</Item>
+        </Grid>
+        <Grid container size={{ xs: 12, md: 7, lg: 8 }} spacing={4}>
+          <Grid size={{ xs: 6, lg: 3 }}>
+            <Item>
+              <Box
+                id="category-a"
+                sx={{ fontSize: '12px', textTransform: 'uppercase' }}
+              >
+                Category A
+              </Box>
+              <Box component="ul" aria-labelledby="category-a" sx={{ pl: 2 }}>
+                <li>Link 1.1</li>
+                <li>Link 1.2</li>
+                <li>Link 1.3</li>
+              </Box>
+            </Item>
+          </Grid>
+          <Grid size={{ xs: 6, lg: 3 }}>
+            <Item>
+              <Box
+                id="category-b"
+                sx={{ fontSize: '12px', textTransform: 'uppercase' }}
+              >
+                Category B
+              </Box>
+              <Box component="ul" aria-labelledby="category-b" sx={{ pl: 2 }}>
+                <li>Link 2.1</li>
+                <li>Link 2.2</li>
+                <li>Link 2.3</li>
+              </Box>
+            </Item>
+          </Grid>
+          <Grid size={{ xs: 6, lg: 3 }}>
+            <Item>
+              <Box
+                id="category-c"
+                sx={{ fontSize: '12px', textTransform: 'uppercase' }}
+              >
+                Category C
+              </Box>
+              <Box component="ul" aria-labelledby="category-c" sx={{ pl: 2 }}>
+                <li>Link 3.1</li>
+                <li>Link 3.2</li>
+                <li>Link 3.3</li>
+              </Box>
+            </Item>
+          </Grid>
+          <Grid size={{ xs: 6, lg: 3 }}>
+            <Item>
+              <Box
+                id="category-d"
+                sx={{ fontSize: '12px', textTransform: 'uppercase' }}
+              >
+                Category D
+              </Box>
+              <Box component="ul" aria-labelledby="category-d" sx={{ pl: 2 }}>
+                <li>Link 4.1</li>
+                <li>Link 4.2</li>
+                <li>Link 4.3</li>
+              </Box>
+            </Item>
+          </Grid>
+        </Grid>
+        <Grid
+          size={12}
+          container
+          direction={{ xs: 'column', sm: 'row' }}
+          sx={{ fontSize: '12px', justifyContent: 'space-between', alignItems: 'center'}}
+        >
+          <Grid sx={{ order: { xs: 2, sm: 1 } }}>
+            <Item>© Copyright</Item>
+          </Grid>
+          <Grid container columnSpacing={1} sx={{ order: { xs: 1, sm: 2 } }}>
+            <Grid>
+              <Item>Link A</Item>
+            </Grid>
+            <Grid>
+              <Item>Link B</Item>
+            </Grid>
+            <Grid>
+              <Item>Link C</Item>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Box>
+  )
+}
+
+function GridDemo9() {
+  return (
+    <Grid container spacing={2} columns={16}>
+      <Grid size={{xs: 8}}>
+        <Item>size=8</Item>
+      </Grid>
+      <Grid size={{xs: 8}}>
+        <Item>size=8</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+function GridDemo10() {
+  return (
+    <Grid container spacing={3} sx={{ flexGrow: 1 }}>
+      <Grid size={{ xs: 6, md: 2 }} offset={{ xs: 3, md: 0 }}>
+        <Item>1</Item>
+      </Grid>
+      <Grid size={{ xs: 4, md: 2 }} offset={{ md: "auto" }}>
+        <Item>2</Item>
+      </Grid>
+      <Grid size={{ xs: 4, md: 2 }} offset={{ xs: 4, md: 0 }} >
+        <Item>3</Item>
+      </Grid>
+      <Grid size={{ xs: 'grow', md: 6 }} offset={{ md: 2 }}>
+        <Item>4</Item>
+      </Grid>
+    </Grid>
+  )
+}
+
+const demos = [
+  { id: '1', component: GridDemo1 },
+  { id: '2', component: GridDemo2 },
+  { id: '3', component: GridDemo3 },
+  { id: '4', component: GridDemo4 },
+  { id: '5', component: GridDemo5 },
+  { id: '6', component: GridDemo6 },
+  { id: '7', component: GridDemo7 },
+  { id: '8', component: GridDemo8 },
+  { id: '9', component: GridDemo9 },
+  { id: '10', component: GridDemo10 },
 ]
 
 export default function InteractiveGrid() {
 
   return (
-    <div sx={{ p: 2}}>
-    <Grid
-        container
-        spacing={{ xs: 2, md: 3 }}
-        columns={12}
-        sx={{ width: '100%' }}
-      >
-        {items.map(({ id, size, offset, extraText}) => (
-          <Grid key={id} size={size} offset={offset}><Card>Item {id}{extraText}</Card></Grid>
-        ))}
-      </Grid>
-      </div>
+    <div sx={{ p: 2, mb: 16, display: 'flex', flexDirection: 'column', gap: 2}}>
+      <a href="https://mui.com/system/react-grid">Benchmark v5</a>
+      <a href="https://next.mui.com/system/react-grid">Benchmark next</a>
+      {demos.map(demo => {
+        const Demo = demo.component;
+        return (
+          <div key={demo.id} sx={{ flex: '1 1 0', pb: 4, borderBottom: '1px solid gray' }}>
+            <h3>Grid Demo {demo.id}</h3>
+            <Demo />
+          </div>
+        );
+      })}
+    </div>
   );
 }

--- a/apps/pigment-css-vite-app/src/pages/grid.tsx
+++ b/apps/pigment-css-vite-app/src/pages/grid.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import Grid from '@pigment-css/react/Grid';
+import { styled } from '@pigment-css/react';
+
+const Card = styled.div`
+  transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  border-radius: 4px;
+  box-shadow:
+    rgba(0, 0, 0, 0.2) 0px 2px 1px -1px,
+    rgba(0, 0, 0, 0.14) 0px 1px 1px 0px,
+    rgba(0, 0, 0, 0.12) 0px 1px 3px 0px;
+  background-image: linear-gradient(rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.05));
+  padding: 8px 16px;
+  font-family: Roboto, Helvetica, Arial, sans-serif;
+  font-weight: 400;
+  font-size: 0.875rem;
+  line-height: 1.43;
+  letter-spacing: 0.01071em;
+  background-color: rgb(26, 32, 39);
+  width: 100%;
+  text-wrap: nowrap;
+  color: white;
+`;
+
+const items = [
+  { id: '1', size: 1, offset: 0},
+  { id: '2', size: 1, offset: 0},
+  { id: '3', size: 1, offset: 0},
+  { id: '4', size: 1, offset: 0},
+  { id: '5', size: 1, offset: 0},
+  { id: '6', size: 1, offset: 0},
+]
+
+export default function InteractiveGrid() {
+
+  return (
+    <Grid
+        container
+        columnSpacing={2}
+        rowSpacing={1}
+        columns={{ xs: 2, md: 6 }}
+        direction={'row'}
+        sx={{ width: '100%' }}
+      >
+        {items.map(({ id, size, offset}) => (
+          <Grid key={id} size={size} offset={offset}><Card>Item {id}</Card></Grid>
+        ))}
+      </Grid>
+  );
+}

--- a/packages/pigment-css-react/package.json
+++ b/packages/pigment-css-react/package.json
@@ -161,6 +161,15 @@
       },
       "require": "./build/Stack.js",
       "default": "./build/Stack.js"
+    },
+    "./Grid": {
+      "types": "./build/Grid.d.ts",
+      "import": {
+        "types": "./build/Grid.d.mts",
+        "default": "./build/Grid.mjs"
+      },
+      "require": "./build/Grid.js",
+      "default": "./build/Grid.js"
     }
   },
   "nx": {

--- a/packages/pigment-css-react/src/Grid.d.ts
+++ b/packages/pigment-css-react/src/Grid.d.ts
@@ -1,0 +1,20 @@
+import * as CSS from 'csstype';
+
+import { Breakpoint } from './base';
+import { PolymorphicComponent } from './Box';
+
+type CssProperty<T> = T | Array<T> | Partial<Record<Breakpoint, T>>;
+
+type GridBaseProps = {
+  display?: CssProperty<'flex' | 'inline-flex'>;
+  spacing?: CssProperty<number | string>;
+  direction?: CssProperty<CSS.StandardLonghandProperties['flexDirection']>;
+  justifyContent?: CssProperty<CSS.StandardLonghandProperties['justifyContent']>;
+  alignItems?: CssProperty<CSS.StandardLonghandProperties['alignItems']>;
+  divider?: React.ReactNode;
+  className?: string;
+};
+
+declare const Grid: PolymorphicComponent<GridBaseProps>;
+
+export default Grid;

--- a/packages/pigment-css-react/src/Grid.d.ts
+++ b/packages/pigment-css-react/src/Grid.d.ts
@@ -6,13 +6,15 @@ import { PolymorphicComponent } from './Box';
 type CssProperty<T> = T | Array<T> | Partial<Record<Breakpoint, T>>;
 
 type GridBaseProps = {
-  display?: CssProperty<'flex' | 'inline-flex'>;
-  spacing?: CssProperty<number | string>;
-  direction?: CssProperty<CSS.StandardLonghandProperties['flexDirection']>;
-  justifyContent?: CssProperty<CSS.StandardLonghandProperties['justifyContent']>;
-  alignItems?: CssProperty<CSS.StandardLonghandProperties['alignItems']>;
-  divider?: React.ReactNode;
   className?: string;
+  columns?: CssProperty<number>;
+  columnSpacing?: CssProperty<number | string>;
+  container?: boolean;
+  direction?: CssProperty<CSS.StandardLonghandProperties['flexDirection']>;
+  offset?: CssProperty<number | 'auto'>;
+  rowSpacing?: CssProperty<number | string>;
+  size?: CssProperty<number | 'grow' | 'auto'>;
+  spacing?: CssProperty<number | string>;
 };
 
 declare const Grid: PolymorphicComponent<GridBaseProps>;

--- a/packages/pigment-css-react/src/Grid.jsx
+++ b/packages/pigment-css-react/src/Grid.jsx
@@ -26,7 +26,7 @@ const Grid = React.forwardRef(function Grid(
     className,
     display = 'flex',
     component = 'div',
-    direction = 'column',
+    direction = 'row',
     flexWrap = 'wrap',
     columns = 12,
     container = false,

--- a/packages/pigment-css-react/src/Grid.jsx
+++ b/packages/pigment-css-react/src/Grid.jsx
@@ -8,20 +8,18 @@ import { gridAtomics } from './baseAtomics';
 import styled from './styled';
 
 const GridComponent = styled('div')({
+  width: 'var(--Column-width)',
+  maxWidth: 'var(--Column-max-width)',
+  flex: 'var(--Column-flex)',
+  marginLeft: 'var(--Item-margin-left)',
   variants: [
     {
       props: { container: true },
       style: {
+        display: 'flex',
         gap: 'var(--Row-gap) var(--Column-gap)',
       }
     },
-    {
-      props: { container: false },
-      style: {
-        width: 'calc(100% * var(--Column-span) / var(--Column-count) - (var(--Column-count) - var(--Column-span)) * var(--Column-gap) / var(--Column-count))',
-        marginLeft: 'calc(100% * var(--Item-offset) / var(--Column-count) + var(--Column-gap) * var(--Item-offset) / var(--Column-count))'
-      }
-    }
   ]
 })
 
@@ -33,7 +31,6 @@ const Grid = React.forwardRef(function Grid(
     rowSpacing,
     style,
     className,
-    display = 'flex',
     component = 'div',
     direction = 'row',
     flexWrap = 'wrap',
@@ -48,7 +45,6 @@ const Grid = React.forwardRef(function Grid(
   ref,
 ) {
   const GridAtomicsObj = {
-    display,
     direction,
     flexWrap,
   };
@@ -73,9 +69,14 @@ const Grid = React.forwardRef(function Grid(
   }
   if (size) {
     GridAtomicsObj['--Column-span'] = size;
+    GridAtomicsObj['--Column-width'] = size;
+    GridAtomicsObj['--Column-max-width'] = size;
+    GridAtomicsObj['--Column-flex'] = size;
+    
   }
   if (offset) {
     GridAtomicsObj['--Item-offset'] = offset;
+    GridAtomicsObj['--Item-margin-left'] = offset;
   }
 
   const ownerState = { container };

--- a/packages/pigment-css-react/src/Grid.jsx
+++ b/packages/pigment-css-react/src/Grid.jsx
@@ -1,0 +1,198 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+/* eslint-disable react/jsx-filename-extension */
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+
+import { gridAtomics } from './baseAtomics';
+
+
+const itemStyle = {
+  width: 'calc(100% * var(--Column-span) / var(--Column-count) - (var(--Column-count) - var(--Column-span)) * var(--Column-gap) / var(--Column-count))',
+  marginLeft: 'calc(100% * var(--Item-offset) / var(--Column-count) + var(--Column-gap) * var(--Item-offset) / var(--Column-count))'
+}
+
+const containerStyle = {
+  gap: 'var(--Row-gap) var(--Column-gap)',
+}
+
+const Grid = React.forwardRef(function Grid(
+  {
+    children,
+    spacing = 0,
+    columnSpacing,
+    rowSpacing,
+    style,
+    className,
+    display = 'flex',
+    component = 'div',
+    direction = 'column',
+    flexWrap = 'wrap',
+    columns = 12,
+    container = false,
+    size,
+    offset,
+    alignItems,
+    justifyContent,
+    ...rest
+  },
+  ref,
+) {
+  const GridAtomicsObj = {
+    display,
+    direction,
+    flexWrap,
+  };
+  if (alignItems) {
+    GridAtomicsObj.alignItems = alignItems;
+  }
+  if (justifyContent) {
+    GridAtomicsObj.justifyContent = justifyContent;
+  }
+  if (container) {
+    GridAtomicsObj['--Column-count'] = columns;
+    GridAtomicsObj['--Column-gap'] = spacing;
+    GridAtomicsObj['--Row-gap'] = spacing;
+
+    if (columnSpacing) {
+      GridAtomicsObj['--Column-gap'] = columnSpacing;
+    }
+
+    if (rowSpacing) {
+      GridAtomicsObj['--Row-gap'] = rowSpacing;
+    }
+  }
+  if (size) {
+    GridAtomicsObj['--Column-span'] = size;
+  }
+  if (offset) {
+    GridAtomicsObj['--Item-offset'] = offset;
+  }
+  const GridClasses = gridAtomics(GridAtomicsObj);
+  const Component = component;
+  return (
+    <Component
+      ref={ref}
+      className={clsx(GridClasses.className, className)}
+      style={{ ...(container ? containerStyle : itemStyle), ...style, ...GridClasses.style }}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+});
+
+process.env.NODE_ENV !== 'production'
+  ? (Grid.propTypes /* remove-proptypes */ = {
+      // ┌────────────────────────────── Warning ──────────────────────────────┐
+      // │ These PropTypes are generated from the TypeScript type definitions. │
+      // │    To update them, edit the d.ts file and run `pnpm proptypes`.     │
+      // └─────────────────────────────────────────────────────────────────────┘
+      /**
+       * @ignore
+       */
+      alignItems: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+        PropTypes.oneOf([
+          'center',
+          'end',
+          'flex-end',
+          'flex-start',
+          'self-end',
+          'self-start',
+          'start',
+          'baseline',
+          'normal',
+          'stretch',
+        ]),
+        PropTypes.arrayOf(
+          PropTypes.oneOf([
+            'center',
+            'end',
+            'flex-end',
+            'flex-start',
+            'self-end',
+            'self-start',
+            'start',
+            'baseline',
+            'normal',
+            'stretch',
+          ]),
+        ),
+        PropTypes.object,
+      ]),
+      /**
+       * The content of the component.
+       */
+      children: PropTypes.node,
+      /**
+       * @ignore
+       */
+      className: PropTypes.string,
+      /**
+       * The component used for the root node.
+       * Either a string to use a HTML element or a component.
+       */
+      component: PropTypes.elementType,
+      /**
+       * @ignore
+       */
+      direction: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+        PropTypes.oneOf(['column', 'column-reverse', 'row', 'row-reverse']),
+        PropTypes.arrayOf(PropTypes.oneOf(['column', 'column-reverse', 'row', 'row-reverse'])),
+        PropTypes.object,
+      ]),
+      /**
+       * @ignore
+       */
+      display: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+        PropTypes.oneOf(['flex', 'inline-flex']),
+        PropTypes.arrayOf(PropTypes.oneOf(['flex', 'inline-flex']).isRequired),
+        PropTypes.object,
+      ]),
+      /**
+       * @ignore
+       */
+      divider: PropTypes.node,
+      /**
+       * @ignore
+       */
+      justifyContent: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+        PropTypes.oneOf([
+          'end',
+          'start',
+          'flex-end',
+          'flex-start',
+          'center',
+          'space-between',
+          'space-around',
+          'space-evenly',
+        ]),
+        PropTypes.arrayOf(
+          PropTypes.oneOf([
+            'end',
+            'start',
+            'flex-end',
+            'flex-start',
+            'center',
+            'space-between',
+            'space-around',
+            'space-evenly',
+          ]),
+        ),
+        PropTypes.object,
+      ]),
+      /**
+       * @ignore
+       */
+      spacing: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired),
+        PropTypes.number,
+        PropTypes.object,
+        PropTypes.string,
+      ]),
+    })
+  : void 0;
+
+Grid.displayName = 'Grid';
+
+export default Grid;

--- a/packages/pigment-css-react/src/Grid.jsx
+++ b/packages/pigment-css-react/src/Grid.jsx
@@ -5,16 +5,25 @@ import PropTypes from 'prop-types';
 import * as React from 'react';
 
 import { gridAtomics } from './baseAtomics';
+import styled from './styled';
 
-
-const itemStyle = {
-  width: 'calc(100% * var(--Column-span) / var(--Column-count) - (var(--Column-count) - var(--Column-span)) * var(--Column-gap) / var(--Column-count))',
-  marginLeft: 'calc(100% * var(--Item-offset) / var(--Column-count) + var(--Column-gap) * var(--Item-offset) / var(--Column-count))'
-}
-
-const containerStyle = {
-  gap: 'var(--Row-gap) var(--Column-gap)',
-}
+const GridComponent = styled('div')({
+  variants: [
+    {
+      props: { container: true },
+      style: {
+        gap: 'var(--Row-gap) var(--Column-gap)',
+      }
+    },
+    {
+      props: { container: false },
+      style: {
+        width: 'calc(100% * var(--Column-span) / var(--Column-count) - (var(--Column-count) - var(--Column-span)) * var(--Column-gap) / var(--Column-count))',
+        marginLeft: 'calc(100% * var(--Item-offset) / var(--Column-count) + var(--Column-gap) * var(--Item-offset) / var(--Column-count))'
+      }
+    }
+  ]
+})
 
 const Grid = React.forwardRef(function Grid(
   {
@@ -68,17 +77,21 @@ const Grid = React.forwardRef(function Grid(
   if (offset) {
     GridAtomicsObj['--Item-offset'] = offset;
   }
+
+  const ownerState = { container };
+
   const GridClasses = gridAtomics(GridAtomicsObj);
-  const Component = component;
   return (
-    <Component
+    <GridComponent
+      as={component}
       ref={ref}
       className={clsx(GridClasses.className, className)}
-      style={{ ...(container ? containerStyle : itemStyle), ...style, ...GridClasses.style }}
+      style={{ ...style, ...GridClasses.style }}
       {...rest}
+      ownerState={ownerState}
     >
       {children}
-    </Component>
+    </GridComponent>
   );
 });
 

--- a/packages/pigment-css-react/src/Stack.jsx
+++ b/packages/pigment-css-react/src/Stack.jsx
@@ -23,7 +23,9 @@ const stackAtomics = generateAtomics(({ theme }) => {
       direction: ['flexDirection'],
       spacing: ['gap'],
     },
-    multiplier: Array.isArray(theme.vars?.spacing) ? theme.vars.spacing[0] : theme.vars?.spacing,
+    multipliers: {
+      gap: Array.isArray(theme.vars?.spacing) ? theme.vars.spacing[0] : theme.vars?.spacing
+    },
   };
 });
 

--- a/packages/pigment-css-react/src/baseAtomics.js
+++ b/packages/pigment-css-react/src/baseAtomics.js
@@ -1,0 +1,95 @@
+import { generateAtomics } from './generateAtomics';
+
+export const stackAtomics = generateAtomics(({ theme }) => ({
+  conditions: Object.keys(theme.breakpoints.values).reduce((acc, breakpoint) => {
+    acc[breakpoint] = `@media (min-width: ${theme.breakpoints.values[breakpoint]}${
+      theme.breakpoints.unit ?? 'px'
+    })`;
+    return acc;
+  }, {}),
+  defaultCondition: theme.breakpoints?.keys?.[0] ?? 'xs',
+  properties: {
+    display: ['flex', 'inline-flex'],
+    flexDirection: ['column', 'column-reverse', 'row', 'row-reverse'],
+    justifyContent: [
+      'end',
+      'start',
+      'flex-end',
+      'flex-start',
+      'center',
+      'space-between',
+      'space-around',
+      'space-evenly',
+    ],
+    alignItems: [
+      'center',
+      'end',
+      'flex-end',
+      'flex-start',
+      'self-end',
+      'self-start',
+      'start',
+      'baseline',
+      'normal',
+      'stretch',
+    ],
+    gap: ['--Stack-gap'],
+  },
+  shorthands: {
+    direction: ['flexDirection'],
+    spacing: ['gap'],
+  },
+  multipliers: {
+    gap: 8,
+  },
+}));
+
+export const gridAtomics = generateAtomics(({ theme }) => ({
+  conditions: Object.keys(theme.breakpoints.values).reduce((acc, breakpoint) => {
+    acc[breakpoint] = `@media (min-width: ${theme.breakpoints.values[breakpoint]}${
+      theme.breakpoints.unit ?? 'px'
+    })`;
+    return acc;
+  }, {}),
+  defaultCondition: theme.breakpoints?.keys?.[0] ?? 'xs',
+  properties: {
+    display: ['flex', 'inline-flex'],
+    flexDirection: ['column', 'column-reverse', 'row', 'row-reverse'],
+    flexWrap: ['wrap', 'nowrap', 'wrap-reverse'],
+    justifyContent: [
+      'end',
+      'start',
+      'flex-end',
+      'flex-start',
+      'center',
+      'space-between',
+      'space-around',
+      'space-evenly',
+    ],
+    alignItems: [
+      'center',
+      'end',
+      'flex-end',
+      'flex-start',
+      'self-end',
+      'self-start',
+      'start',
+      'baseline',
+      'normal',
+      'stretch',
+    ],
+    '--Column-count': ['--Column-count'],
+    '--Column-span': ['--Column-span'],
+    '--Column-gap': ['--Column-gap'],
+    '--Row-gap': ['--Row-gap'],
+    '--Item-offset': ['--Item-offset']
+  },
+  shorthands: {
+    direction: ['flexDirection'],
+  },
+  unitless: ['--Column-count', '--Column-span', '--Item-offset'],
+  multipliers: {
+    '--Column-gap': 8,
+    '--Row-gap': 8,
+  },
+}));

--- a/packages/pigment-css-react/src/baseAtomics.js
+++ b/packages/pigment-css-react/src/baseAtomics.js
@@ -53,51 +53,31 @@ export const gridAtomics = generateAtomics(({ theme }) => ({
   }, {}),
   defaultCondition: theme.breakpoints?.keys?.[0] ?? 'xs',
   properties: {
-    display: ['flex', 'inline-flex'],
     flexDirection: ['column', 'column-reverse', 'row', 'row-reverse'],
-    flexWrap: ['wrap', 'nowrap', 'wrap-reverse'],
-    justifyContent: [
-      'end',
-      'start',
-      'flex-end',
-      'flex-start',
-      'center',
-      'space-between',
-      'space-around',
-      'space-evenly',
-    ],
-    alignItems: [
-      'center',
-      'end',
-      'flex-end',
-      'flex-start',
-      'self-end',
-      'self-start',
-      'start',
-      'baseline',
-      'normal',
-      'stretch',
-    ],
-    '--Column-width': ['--Column-width'],
-    '--Column-max-width': ['--Column-max-width'],
-    '--Column-flex': ['--Column-flex'],
-    '--Column-count': ['--Column-count'],
-    '--Column-span': ['--Column-span'],
-    '--Column-gap': ['--Column-gap'],
-    '--Row-gap': ['--Row-gap'],
-    '--Item-offset': ['--Item-offset'],
-    '--Item-margin-left': ['--Item-margin-left'],
+    '--Grid-parent-column-count': ['--Grid-parent-column-count'],
+    '--Grid-parent-column-spacing': ['--Grid-parent-column-spacing'],
+    '--Grid-parent-row-spacing': ['--Grid-parent-row-spacing'],
+    '--Grid-self-column-span': ['--Grid-self-column-span'],
+    '--Grid-self-width': ['--Grid-self-width'],
+    '--Grid-self-max-width': ['--Grid-self-max-width'],
+    '--Grid-self-flex': ['--Grid-self-flex'],
+    '--Grid-self-column-spacing': ['--Grid-self-column-spacing'],
+    '--Grid-self-row-spacing': ['--Grid-self-row-spacing'],
+    '--Grid-self-offset': ['--Grid-self-offset'],
+    '--Grid-self-margin-left': ['--Grid-self-margin-left'],
   },
   shorthands: {
     direction: ['flexDirection'],
   },
-  unitless: ['--Column-count', '--Column-span', '--Item-offset'],
+  unitless: ['--Grid-parent-column-count', '--Grid-self-column-span', '--Grid-self-offset'],
   multipliers: {
-    '--Column-gap': 8,
-    '--Row-gap': 8,
+    '--Grid-parent-column-spacing': 8,
+    '--Grid-parent-row-spacing': 8,
+    '--Grid-self-column-spacing': 8,
+    '--Grid-self-row-spacing': 8,
   },
   inlineGetters: {
-    '--Column-width': (value) => {
+    '--Grid-self-width': (value) => {
       if (value === 'grow') {
         return 'unset';
       }
@@ -106,9 +86,9 @@ export const gridAtomics = generateAtomics(({ theme }) => ({
         return 'auto';
       }
 
-      return 'calc(100% * var(--Column-span) / var(--Column-count) - (var(--Column-count) - var(--Column-span)) * var(--Column-gap) / var(--Column-count))';
+      return 'calc(100% * var(--Grid-self-column-span) / var(--Grid-parent-column-count) - (var(--Grid-parent-column-count) - var(--Grid-self-column-span)) * var(--Grid-parent-column-spacing) / var(--Grid-parent-column-count))';
     },
-    '--Column-max-width': (value) => {
+    '--Grid-self-max-width': (value) => {
       if (value === 'grow') {
         return '100%';
       }
@@ -119,7 +99,7 @@ export const gridAtomics = generateAtomics(({ theme }) => ({
 
       return 'unset';
     },
-    '--Column-flex': (value) => {
+    '--Grid-self-flex': (value) => {
       if (value === 'grow') {
         return '1 1 0';
       }
@@ -130,12 +110,12 @@ export const gridAtomics = generateAtomics(({ theme }) => ({
 
       return '0 1 auto';
     },
-    '--Item-margin-left': (value) => {
+    '--Grid-self-margin-left': (value) => {
       if (value === 'auto') {
         return 'auto';
       }
 
-      return 'calc(100% * var(--Item-offset) / var(--Column-count) + var(--Column-gap) * var(--Item-offset) / var(--Column-count))';
+      return 'calc(100% * var(--Grid-self-offset) / var(--Grid-parent-column-count) + var(--Grid-parent-column-spacing) * var(--Grid-self-offset) / var(--Grid-parent-column-count))';
     },
   },
 }));

--- a/packages/pigment-css-react/src/baseAtomics.js
+++ b/packages/pigment-css-react/src/baseAtomics.js
@@ -71,10 +71,10 @@ export const gridAtomics = generateAtomics(({ theme }) => ({
   },
   unitless: ['--Grid-parent-column-count', '--Grid-self-column-span', '--Grid-self-offset'],
   multipliers: {
-    '--Grid-parent-column-spacing': 8,
-    '--Grid-parent-row-spacing': 8,
-    '--Grid-self-column-spacing': 8,
-    '--Grid-self-row-spacing': 8,
+    '--Grid-parent-column-spacing': Array.isArray(theme.vars?.spacing) ? theme.vars.spacing[0] : theme.vars?.spacing,
+    '--Grid-parent-row-spacing': Array.isArray(theme.vars?.spacing) ? theme.vars.spacing[0] : theme.vars?.spacing,
+    '--Grid-self-column-spacing': Array.isArray(theme.vars?.spacing) ? theme.vars.spacing[0] : theme.vars?.spacing,
+    '--Grid-self-row-spacing': Array.isArray(theme.vars?.spacing) ? theme.vars.spacing[0] : theme.vars?.spacing,
   },
   inlineGetters: {
     '--Grid-self-width': (value) => {

--- a/packages/pigment-css-react/src/baseAtomics.js
+++ b/packages/pigment-css-react/src/baseAtomics.js
@@ -78,11 +78,15 @@ export const gridAtomics = generateAtomics(({ theme }) => ({
       'normal',
       'stretch',
     ],
+    '--Column-width': ['--Column-width'],
+    '--Column-max-width': ['--Column-max-width'],
+    '--Column-flex': ['--Column-flex'],
     '--Column-count': ['--Column-count'],
     '--Column-span': ['--Column-span'],
     '--Column-gap': ['--Column-gap'],
     '--Row-gap': ['--Row-gap'],
-    '--Item-offset': ['--Item-offset']
+    '--Item-offset': ['--Item-offset'],
+    '--Item-margin-left': ['--Item-margin-left'],
   },
   shorthands: {
     direction: ['flexDirection'],
@@ -91,5 +95,47 @@ export const gridAtomics = generateAtomics(({ theme }) => ({
   multipliers: {
     '--Column-gap': 8,
     '--Row-gap': 8,
+  },
+  inlineGetters: {
+    '--Column-width': (value) => {
+      if (value === 'grow') {
+        return 'unset';
+      }
+
+      if (value === 'auto') {
+        return 'auto';
+      }
+
+      return 'calc(100% * var(--Column-span) / var(--Column-count) - (var(--Column-count) - var(--Column-span)) * var(--Column-gap) / var(--Column-count))';
+    },
+    '--Column-max-width': (value) => {
+      if (value === 'grow') {
+        return '100%';
+      }
+
+      if (value === 'auto') {
+        return 'none';
+      }
+
+      return 'unset';
+    },
+    '--Column-flex': (value) => {
+      if (value === 'grow') {
+        return '1 1 0';
+      }
+
+      if (value === 'auto') {
+        return '0 0 auto';
+      }
+
+      return '0 1 auto';
+    },
+    '--Item-margin-left': (value) => {
+      if (value === 'auto') {
+        return 'auto';
+      }
+
+      return 'calc(100% * var(--Item-offset) / var(--Column-count) + var(--Column-gap) * var(--Item-offset) / var(--Column-count))';
+    },
   },
 }));

--- a/packages/pigment-css-react/src/generateAtomics.js
+++ b/packages/pigment-css-react/src/generateAtomics.js
@@ -12,7 +12,8 @@ export function generateAtomics() {
  * @property {Object.<string, string[]>} shorthands
  * @property {string[]} conditions
  * @property {string} defaultCondition
- * @property {string} multiplier
+ * @property {string[]} unitless
+ * @property {string} multipliers
  */
 
 /**
@@ -21,14 +22,21 @@ export function generateAtomics() {
  *
  * @param {RuntimeConfig} runtimeConfig
  */
-export function atomics({ styles, shorthands, conditions, defaultCondition, multiplier }) {
+export function atomics({
+  styles,
+  shorthands,
+  conditions,
+  defaultCondition,
+  unitless,
+  multipliers = {},
+}) {
   function addStyles(cssProperty, propertyValue, classes, inlineStyle) {
     const styleClasses = styles[cssProperty];
     if (!styleClasses) {
       return;
     }
 
-    function handlePrimitive(value, breakpoint = defaultCondition) {
+    function handlePrimitive(value, multiplier = 1, breakpoint = defaultCondition) {
       if (!(value in styleClasses)) {
         const keys = Object.keys(styleClasses);
         if (keys.length !== 1) {
@@ -48,7 +56,7 @@ export function atomics({ styles, shorthands, conditions, defaultCondition, mult
     }
 
     if (typeof propertyValue === 'string' || typeof propertyValue === 'number') {
-      handlePrimitive(propertyValue);
+      handlePrimitive(propertyValue, multipliers[cssProperty]);
     } else if (Array.isArray(propertyValue)) {
       propertyValue.forEach((value, index) => {
         if (value) {
@@ -56,7 +64,7 @@ export function atomics({ styles, shorthands, conditions, defaultCondition, mult
           if (!breakpoint) {
             return;
           }
-          handlePrimitive(value, conditions[index]);
+          handlePrimitive(value, multipliers[cssProperty], conditions[index]);
         }
       });
     } else if (propertyValue) {
@@ -64,7 +72,7 @@ export function atomics({ styles, shorthands, conditions, defaultCondition, mult
         if (propertyValue[condition]) {
           const propertyClasses = styleClasses[propertyValue[condition]];
           if (!propertyClasses) {
-            handlePrimitive(propertyValue[condition], condition);
+            handlePrimitive(propertyValue[condition], multipliers[cssProperty], condition);
             return;
           }
           classes.push(propertyClasses[condition]);

--- a/packages/pigment-css-react/src/utils/convertAtomicsToCss.ts
+++ b/packages/pigment-css-react/src/utils/convertAtomicsToCss.ts
@@ -66,9 +66,7 @@ export function convertAtomicsToCss(
     Object.entries(properties).forEach(([cssPropertyName, propertyValues]) => {
       propertyValues.forEach((propertyValue) => {
         const propValue = propertyValue.startsWith('--')
-          ? cssesc(
-              `var(${propertyValue}${conditionName === defaultCondition ? '' : `-${conditionName}`})`,
-            )
+          ? cssesc(`var(${propertyValue}-${conditionName})`)
           : propertyValue;
         const className =
           isGlobal || debug

--- a/packages/pigment-css-react/src/utils/convertAtomicsToCss.ts
+++ b/packages/pigment-css-react/src/utils/convertAtomicsToCss.ts
@@ -7,7 +7,8 @@ export type Atomics = {
     [key: string]: string[];
   };
   shorthands: Record<string, string[]>;
-  multiplier?: string;
+  unitless: string[];
+  multipliers?: Record<string, string>;
 };
 
 export type RuntimeConfig = {
@@ -15,7 +16,8 @@ export type RuntimeConfig = {
   styles: Record<string, Record<string, Record<string, string>>>;
   shorthands: Atomics['shorthands'];
   defaultCondition: string;
-  multiplier?: string;
+  unitless: string[];
+  multipliers?: Record<string, string>;
 };
 
 function getClassName(...items: string[]) {
@@ -28,7 +30,8 @@ export function convertAtomicsToCss(
     defaultCondition,
     properties,
     shorthands = {},
-    multiplier = undefined,
+    unitless = [],
+    multipliers = {},
   }: Atomics,
   mainClassName: string,
   isGlobal = false,
@@ -40,7 +43,8 @@ export function convertAtomicsToCss(
     shorthands,
     conditions: Object.keys(conditions),
     defaultCondition,
-    multiplier,
+    unitless,
+    multipliers,
   };
   let count = 1;
   function getCount() {

--- a/packages/pigment-css-react/src/utils/convertAtomicsToCss.ts
+++ b/packages/pigment-css-react/src/utils/convertAtomicsToCss.ts
@@ -9,6 +9,7 @@ export type Atomics = {
   shorthands: Record<string, string[]>;
   unitless: string[];
   multipliers?: Record<string, string>;
+  inlineGetters: Record<string, (value: string) => string>;
 };
 
 export type RuntimeConfig = {
@@ -18,6 +19,7 @@ export type RuntimeConfig = {
   defaultCondition: string;
   unitless: string[];
   multipliers?: Record<string, string>;
+  inlineGetters: Record<string, (value: string) => string>;
 };
 
 function getClassName(...items: string[]) {
@@ -32,6 +34,7 @@ export function convertAtomicsToCss(
     shorthands = {},
     unitless = [],
     multipliers = {},
+    inlineGetters = {},
   }: Atomics,
   mainClassName: string,
   isGlobal = false,
@@ -45,6 +48,7 @@ export function convertAtomicsToCss(
     defaultCondition,
     unitless,
     multipliers,
+    inlineGetters,
   };
   let count = 1;
   function getCount() {

--- a/packages/pigment-css-react/tests/generateAtomics.test.js
+++ b/packages/pigment-css-react/tests/generateAtomics.test.js
@@ -65,7 +65,7 @@ describe('generateAtomics', () => {
     ).to.deep.equal({
       className: 'gap--Stack-gap-lg gap--Stack-gap-xs',
       style: {
-        '--Stack-gap': 'calc(2 * 8px)',
+        '--Stack-gap-xs': 'calc(2 * 8px)',
         '--Stack-gap-lg': 'calc(1 * 8px)',
       },
     });
@@ -80,7 +80,7 @@ describe('generateAtomics', () => {
     ).to.deep.equal({
       className: 'flex-direction-row-xs gap--Stack-gap-xs',
       style: {
-        '--Stack-gap': 'calc(1 * 8px)',
+        '--Stack-gap-xs': 'calc(1 * 8px)',
       },
     });
   });
@@ -107,7 +107,7 @@ describe('generateAtomics', () => {
       className:
         'flex-direction-row-xs flex-direction-column-sm gap--Stack-gap-xs gap--Stack-gap-sm',
       style: {
-        '--Stack-gap': 'calc(1 * 8px)',
+        '--Stack-gap-xs': 'calc(1 * 8px)',
         '--Stack-gap-sm': 'calc(2 * 8px)',
       },
     });
@@ -135,7 +135,7 @@ describe('generateAtomics', () => {
       className:
         'flex-direction-row-xs flex-direction-column-sm gap--Stack-gap-xs gap--Stack-gap-sm',
       style: {
-        '--Stack-gap': 'calc(1 * 8px)',
+        '--Stack-gap-xs': 'calc(1 * 8px)',
         '--Stack-gap-sm': 'calc(2 * 8px)',
       },
     });

--- a/packages/pigment-css-react/tests/generateAtomics.test.js
+++ b/packages/pigment-css-react/tests/generateAtomics.test.js
@@ -47,7 +47,10 @@ const atomic = atomics({
   // @ts-ignore This is not expected while calling the pre-transpiled generateAtomics
   conditions: ['xs', 'sm', 'md', 'lg', 'xl'],
   defaultCondition: 'xs',
-  multiplier: '8px',
+  unitless: [],
+  multipliers: {
+    gap: '8px',
+  },
 });
 
 describe('generateAtomics', () => {

--- a/packages/pigment-css-react/tsup.config.ts
+++ b/packages/pigment-css-react/tsup.config.ts
@@ -20,7 +20,7 @@ const baseConfig: Options = {
   external,
 };
 
-const BASE_FILES = ['index.ts', 'theme.ts', 'Box.jsx', 'RtlProvider.tsx', 'Stack.jsx'];
+const BASE_FILES = ['index.ts', 'theme.ts', 'Box.jsx', 'RtlProvider.tsx', 'Stack.jsx', 'Grid.jsx'];
 
 export default defineConfig([
   {


### PR DESCRIPTION
Create Grid component following the atomics approach, same as https://github.com/mui/pigment-css/pull/118.

## Summary

This is the Pigment version of the Grid v2 component. It supports all the use cases the original supports but has some API differences:

- Instead of using the breakpoints as props for size (`xs`, `sm`, `md`, ...), there's a `size` prop. Some conversions
  - `xs={2}` turns into `size={2}`
  - `xs={2} md={4}` turns into `size={{ xs: 2, md: 4 }}`
  - `xs` turns into `size='grow'`
  - `xs='auto'` turns into `size='auto'`
  - `xs={2} sm md={4} lg='auto'` turns into `size={{ xs: 2, sm: 'grow', md: 4, lg: 'auto' }}`
- Instead of using the breakpoints as props for offset (`xsOffset`, `smOffset`, `mdOffset`, ...), there's a `offset` prop. Some conversions
  - `xsOffset={2}` turns into `offset={2}`
  - `xsOffset={2} mdOffset={4}` turns into `offset={{ xs: 2, md: 4 }}`
  - `xsOffset='auto'` turns into `offset='auto'`
  - `xsOffset={2} mdOffset={4} lgOffset='auto'` turns into `offset={{ xs: 2, md: 4, lg: 'auto' }}`

This was done as it works better with the no runtime approach. It might be possible to maintain the previous API, but I don't think it's worth it as it might introduce some tech debt, and this API is more consistent IMO. It is also easy to cover with a codemod.

The original Grid v2 uses a `unstable_level` prop for nesting grids. This uses a similar approach but instead of levels it takes advantage of CSS variable scoping. This is the only way I could find to achieve nested grids.

## Play with the Grid

```bash
// project root
pnpm build

// pigment-css-vite-app
pnpm install
pnpm dev
```

The demo is at `http://localhost:5173/grid` and the code is at `apps/pigment-css-vite-app/src/pages/grid.tsx`

## Preview

https://github.com/brijeshb42/pigment-css/assets/16889233/42909b01-345c-4fc1-8374-2737ae7f7629


